### PR TITLE
fix: fixes compilation when `castore` not available

### DIFF
--- a/lib/tower_rollbar/rollbar/client.ex
+++ b/lib/tower_rollbar/rollbar/client.ex
@@ -24,7 +24,8 @@ defmodule TowerRollbar.Rollbar.Client do
   end
 
   cond do
-    function_exported?(:public_key, :cacerts_get, 0) ->
+    Code.ensure_loaded?(:public_key) and
+        function_exported?(:public_key, :cacerts_get, 0) ->
       # Included in Erlang 25+
       defp tls_client_options do
         [


### PR DESCRIPTION
uses `Code.ensure_loaded?` to ask compiler to load `:public_key` module if not yet loaded

this might pop up with phoenix 1.8 that no longer depends on `castore`